### PR TITLE
Adding the fix for Omniauth as of @honglilai recommendation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Open your app's Procfile, or create one if you don't already have one. Remove li
     web: bundle exec unicorn -p $PORT
     web: bundle exec thin start -p $PORT
 
+If you depend on Omniauth to authenticate with Facebook, G+, etc you must add the following lines to your `config/application.rb`:
+
+    config.autoload_paths += Dir["#{config.root}/lib"]
+    config.middleware.insert_before Rails::Rack::Logger, "HerokuNginxHeadersMiddleware"
+
+Copy the `lib/heroku_nginx_headers_middleware.rb` to the `lib` directory in your Rails app.
+
 Insert:
 
     web: bundle exec passenger start -p $PORT --max-pool-size 3

--- a/lib/heroku_nginx_headers_middleware.rb
+++ b/lib/heroku_nginx_headers_middleware.rb
@@ -1,0 +1,13 @@
+# Fixes up headers based on information given by the Heroku router.
+# by @honglilai
+class HerokuNginxHeadersMiddleware
+  def initialize(app)
+    @app = app
+  end
+ 
+  def call(env)
+    env["SERVER_PORT"] = env["HTTP_X_FORWARDED_PORT"]
+    env["REMOTE_ADDR"] = env["HTTP_X_FORWARDED_FOR"]
+    @app.call(env)
+  end
+end


### PR DESCRIPTION
Various libraries, such as Omniauth, may generate incorrect redirection headers when on Heroku+Passenger. The reason for this is because Passenger Standalone uses Nginx, which for security reasons sanitizes various HTTP headers. This results in slightly different reverse proxy behavior compared to Unicorn, Thin, etc.

The following middleware fixes this problem by fixing up various request headers according to information given by the Heroku router.
